### PR TITLE
Fixes / Python 3 compatibility

### DIFF
--- a/rejson/client.py
+++ b/rejson/client.py
@@ -1,7 +1,6 @@
 import six
-from sys import stdout
 import json
-from redis import StrictRedis, exceptions
+from redis import StrictRedis
 from redis.client import BasePipeline
 from redis._compat import (long, nativestr)
 from .path import Path

--- a/rejson/client.py
+++ b/rejson/client.py
@@ -1,3 +1,4 @@
+import six
 from sys import stdout
 import json
 from redis import StrictRedis, exceptions
@@ -14,7 +15,7 @@ def str_path(p):
 
 def float_or_long(n):
     "Return a number from a Redis reply"
-    if isinstance(n, str):
+    if isinstance(n, six.string_types):
         return float(n)
     else:
         return long(n)
@@ -90,7 +91,7 @@ class Client(StrictRedis):
                 'JSON.ARRTRIM': long_or_none,
                 'JSON.OBJLEN': long_or_none,
         }
-        for k, v in MODULE_CALLBACKS.iteritems():
+        for k, v in six.iteritems(MODULE_CALLBACKS):
             self.set_response_callback(k, v)
                                     
     def setEncoder(self, encoder):

--- a/test/test.py
+++ b/test/test.py
@@ -1,5 +1,6 @@
 import json
 import redis
+import unittest
 from unittest import TestCase
 from rejson import Client, Path
 

--- a/test/test.py
+++ b/test/test.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import json
 import redis
 import unittest
@@ -198,14 +199,14 @@ class ReJSONTestCase(TestCase):
         rj.jsonset('obj', Path.rootPath(), obj)
 
         # Get something
-        print 'Is there anybody... {}?'.format(
+        print('Is there anybody... {}?'.format(
             rj.jsonget('obj', Path('.truth.coord'))
-        )
+        ))
 
         # Delete something (or perhaps nothing), append something and pop it
         rj.jsondel('obj', Path('.arr[0]'))
         rj.jsonarrappend('obj', Path('.arr'), 'something')
-        print '{} popped!'.format(rj.jsonarrpop('obj', Path('.arr')))
+        print('{} popped!'.format(rj.jsonarrpop('obj', Path('.arr'))))
 
         # Update something else
         rj.jsonset('obj', Path('.answer'), 2.17)

--- a/test/test.py
+++ b/test/test.py
@@ -4,11 +4,20 @@ import unittest
 from unittest import TestCase
 from rejson import Client, Path
 
+
+rj = None
+port = 6378
+
+
 class ReJSONTestCase(TestCase):
+
+    def setUp(self):
+        global rj
+        rj = Client(port=port, decode_responses=True)
+        rj.flushdb()
+
     def testJSONSetGetDelShouldSucceed(self):
         "Test basic JSONSet/Get/Del"
-        rj = Client()
-        rj.flushdb()
 
         self.assertTrue(rj.jsonset('foo', Path.rootPath(), 'bar'))
         self.assertEqual('bar', rj.jsonget('foo'))
@@ -17,8 +26,6 @@ class ReJSONTestCase(TestCase):
 
     def testMGetShouldSucceed(self):
         "Test JSONMGet"
-        rj = Client()
-        rj.flushdb()
 
         rj.jsonset('1', Path.rootPath(), 1)
         rj.jsonset('2', Path.rootPath(), 2)
@@ -28,16 +35,12 @@ class ReJSONTestCase(TestCase):
 
     def testTypeShouldSucceed(self):
         "Test JSONType"
-        rj = Client()
-        rj.flushdb()
 
         rj.jsonset('1', Path.rootPath(), 1)
         self.assertEqual('integer', rj.jsontype('1'))
 
     def testNumIncrByShouldSucceed(self):
         "Test JSONNumIncrBy"
-        rj = Client()
-        rj.flushdb()
 
         rj.jsonset('num', Path.rootPath(), 1)
         self.assertEqual(2, rj.jsonnumincrby('num', Path.rootPath(), 1))
@@ -46,8 +49,6 @@ class ReJSONTestCase(TestCase):
 
     def testNumMultByShouldSucceed(self):
         "Test JSONNumIncrBy"
-        rj = Client()
-        rj.flushdb()
 
         rj.jsonset('num', Path.rootPath(), 1)
         self.assertEqual(2, rj.jsonnummultby('num', Path.rootPath(), 2))
@@ -56,8 +57,6 @@ class ReJSONTestCase(TestCase):
 
     def testStrAppendShouldSucceed(self):
         "Test JSONStrAppend"
-        rj = Client()
-        rj.flushdb()
 
         rj.jsonset('str', Path.rootPath(), 'foo')
         self.assertEqual(6, rj.jsonstrappend('str', 'bar', Path.rootPath()))
@@ -65,8 +64,6 @@ class ReJSONTestCase(TestCase):
 
     def testStrLenShouldSucceed(self):
         "Test JSONStrLen"
-        rj = Client()
-        rj.flushdb()
 
         rj.jsonset('str', Path.rootPath(), 'foo')
         self.assertEqual(3, rj.jsonstrlen('str', Path.rootPath()))
@@ -75,16 +72,12 @@ class ReJSONTestCase(TestCase):
 
     def testArrAppendShouldSucceed(self):
         "Test JSONSArrAppend"
-        rj = Client()
-        rj.flushdb()
 
         rj.jsonset('arr', Path.rootPath(), [1])
         self.assertEqual(2, rj.jsonarrappend('arr', Path.rootPath(), 2))
 
     def testArrIndexShouldSucceed(self):
         "Test JSONSArrIndex"
-        rj = Client()
-        rj.flushdb()
 
         rj.jsonset('arr', Path.rootPath(), [0, 1, 2, 3, 4])
         self.assertEqual(1, rj.jsonarrindex('arr', Path.rootPath(), 1))
@@ -92,8 +85,6 @@ class ReJSONTestCase(TestCase):
 
     def testArrInsertShouldSucceed(self):
         "Test JSONSArrInsert"
-        rj = Client()
-        rj.flushdb()
 
         rj.jsonset('arr', Path.rootPath(), [0, 4])
         self.assertEqual(5, rj.jsonarrinsert('arr', Path.rootPath(), 1, *[1, 2, 3,]))
@@ -101,16 +92,12 @@ class ReJSONTestCase(TestCase):
 
     def testArrLenShouldSucceed(self):
         "Test JSONSArrLen"
-        rj = Client()
-        rj.flushdb()
 
         rj.jsonset('arr', Path.rootPath(), [0, 1, 2, 3, 4])
         self.assertEqual(5, rj.jsonarrlen('arr', Path.rootPath()))
 
     def testArrPopShouldSucceed(self):
         "Test JSONSArrPop"
-        rj = Client()
-        rj.flushdb()
 
         rj.jsonset('arr', Path.rootPath(), [0, 1, 2, 3, 4])
         self.assertEqual(4, rj.jsonarrpop('arr', Path.rootPath(), 4))
@@ -121,8 +108,6 @@ class ReJSONTestCase(TestCase):
 
     def testArrTrimShouldSucceed(self):
         "Test JSONSArrPop"
-        rj = Client()
-        rj.flushdb()
 
         rj.jsonset('arr', Path.rootPath(), [0, 1, 2, 3, 4])
         self.assertEqual(3, rj.jsonarrtrim('arr', Path.rootPath(), 1, 3))
@@ -130,8 +115,6 @@ class ReJSONTestCase(TestCase):
 
     def testObjKeysShouldSucceed(self):
         "Test JSONSObjKeys"
-        rj = Client()
-        rj.flushdb()
 
         obj = { 'foo': 'bar', 'baz': 'qaz' }
         rj.jsonset('obj', Path.rootPath(), obj)
@@ -143,8 +126,6 @@ class ReJSONTestCase(TestCase):
 
     def testObjLenShouldSucceed(self):
         "Test JSONSObjLen"
-        rj = Client()
-        rj.flushdb()
 
         obj = { 'foo': 'bar', 'baz': 'qaz' }
         rj.jsonset('obj', Path.rootPath(), obj)
@@ -152,8 +133,6 @@ class ReJSONTestCase(TestCase):
 
     def testPipelineShouldSucceed(self):
         "Test pipeline"
-        rj = Client()
-        rj.flushdb()
 
         p = rj.pipeline()
         p.jsonset('foo', Path.rootPath(), 'bar')
@@ -186,7 +165,7 @@ class ReJSONTestCase(TestCase):
                     return CustomClass(k=s[1], v=s[2])
                 return d
 
-        rj = Client(encoder=TestEncoder(), decoder=TestDecoder())
+        rj = Client(encoder=TestEncoder(), decoder=TestDecoder(), port=port)
         rj.flushdb()
 
         # Check a regular string
@@ -206,7 +185,7 @@ class ReJSONTestCase(TestCase):
         "Test the usage example"
 
         # Create a new rejson-py client
-        rj = Client(host='localhost', port=6379)
+        rj = Client(host='localhost', port=port)
 
         # Set the key `obj` to some object
         obj = {

--- a/test/test.py
+++ b/test/test.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 import json
-import redis
 import unittest
 from unittest import TestCase
 from rejson import Client, Path
@@ -88,7 +87,8 @@ class ReJSONTestCase(TestCase):
         "Test JSONSArrInsert"
 
         rj.jsonset('arr', Path.rootPath(), [0, 4])
-        self.assertEqual(5, rj.jsonarrinsert('arr', Path.rootPath(), 1, *[1, 2, 3,]))
+        self.assertEqual(5, rj.jsonarrinsert('arr',
+                                             Path.rootPath(), 1, *[1, 2, 3, ]))
         self.assertListEqual([0, 1, 2, 3, 4], rj.jsonget('arr'))
 
     def testArrLenShouldSucceed(self):
@@ -117,7 +117,7 @@ class ReJSONTestCase(TestCase):
     def testObjKeysShouldSucceed(self):
         "Test JSONSObjKeys"
 
-        obj = { 'foo': 'bar', 'baz': 'qaz' }
+        obj = {'foo': 'bar', 'baz': 'qaz'}
         rj.jsonset('obj', Path.rootPath(), obj)
         keys = rj.jsonobjkeys('obj', Path.rootPath())
         keys.sort()
@@ -128,7 +128,7 @@ class ReJSONTestCase(TestCase):
     def testObjLenShouldSucceed(self):
         "Test JSONSObjLen"
 
-        obj = { 'foo': 'bar', 'baz': 'qaz' }
+        obj = {'foo': 'bar', 'baz': 'qaz'}
         rj.jsonset('obj', Path.rootPath(), obj)
         self.assertEqual(len(obj), rj.jsonobjlen('obj', Path.rootPath()))
 
@@ -140,14 +140,15 @@ class ReJSONTestCase(TestCase):
         p.jsonget('foo')
         p.jsondel('foo')
         p.exists('foo')
-        self.assertListEqual([ True, 'bar', 1, False ], p.execute())
+        self.assertListEqual([True, 'bar', 1, False], p.execute())
 
     def testCustomEncoderDecoderShouldSucceed(self):
         "Test a custom encoder and decoder"
-        
+
         class CustomClass(object):
             key = ''
             val = ''
+
             def __init__(self, k='', v=''):
                 self.key = k
                 self.val = v
@@ -175,7 +176,8 @@ class ReJSONTestCase(TestCase):
         self.assertEqual('bar', rj.jsonget('foo', Path.rootPath()))
 
         # Check the custom encoder
-        self.assertTrue(rj.jsonset('cus', Path.rootPath(), CustomClass('foo', 'bar')))
+        self.assertTrue(rj.jsonset('cus', Path.rootPath(),
+                                   CustomClass('foo', 'bar')))
         obj = rj.jsonget('cus', Path.rootPath())
         self.assertIsNotNone(obj)
         self.assertEqual(CustomClass, obj.__class__)
@@ -216,6 +218,7 @@ class ReJSONTestCase(TestCase):
         jp.set('foo', 'bar')
         jp.jsonset('baz', Path.rootPath(), 'qaz')
         jp.execute()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test.py
+++ b/test/test.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import six
 import json
 import unittest
 from unittest import TestCase
@@ -121,7 +122,7 @@ class ReJSONTestCase(TestCase):
         rj.jsonset('obj', Path.rootPath(), obj)
         keys = rj.jsonobjkeys('obj', Path.rootPath())
         keys.sort()
-        exp = [k for k in obj.iterkeys()]
+        exp = [k for k in six.iterkeys(obj)]
         exp.sort()
         self.assertListEqual(exp, keys)
 
@@ -162,12 +163,14 @@ class ReJSONTestCase(TestCase):
         class TestDecoder(json.JSONDecoder):
             def decode(self, obj):
                 d = json.JSONDecoder.decode(self, obj)
-                if isinstance(d, basestring) and d.startswith('CustomClass:'):
+                if isinstance(d, six.string_types) and \
+                        d.startswith('CustomClass:'):
                     s = d.split(':')
                     return CustomClass(k=s[1], v=s[2])
                 return d
 
-        rj = Client(encoder=TestEncoder(), decoder=TestDecoder(), port=port)
+        rj = Client(encoder=TestEncoder(), decoder=TestDecoder(),
+                    port=port, decode_responses=True)
         rj.flushdb()
 
         # Check a regular string
@@ -188,7 +191,7 @@ class ReJSONTestCase(TestCase):
         "Test the usage example"
 
         # Create a new rejson-py client
-        rj = Client(host='localhost', port=port)
+        rj = Client(host='localhost', port=port, decode_responses=True)
 
         # Set the key `obj` to some object
         obj = {

--- a/test/test.py
+++ b/test/test.py
@@ -7,7 +7,7 @@ from rejson import Client, Path
 
 
 rj = None
-port = 6378
+port = 6379
 
 
 class ReJSONTestCase(TestCase):


### PR DESCRIPTION
Fix:
- import of unittest module (test won't run without this import)

client.py / test.py
- python 3 compatibility by using six

changes to test.py to:
- simplify the tests by using setUp method in testcase
- PEP8 / flake8 corrections

Tests run both 2.7 and 3.5

Gendoc seems pretty incompatible with Python 3.x