### PR TITLE
Add exception handler for .jsonget for non-existent keys + test

### DIFF
--- a/rejson/client.py
+++ b/rejson/client.py
@@ -5,12 +5,14 @@ from redis.client import Pipeline
 from redis._compat import (long, nativestr)
 from .path import Path
 
+
 def str_path(p):
     "Returns the string representation of a path if it is of class Path"
     if isinstance(p, Path):
         return p.strPath
     else:
         return p
+
 
 def bulk_of_jsons(d):
     "Replace serialized JSON values with objects in a bulk array response (list)"
@@ -20,6 +22,7 @@ def bulk_of_jsons(d):
                 b[index] = d(item)
         return b
     return _f
+
 
 class Client(StrictRedis):
     """
@@ -111,7 +114,13 @@ class Client(StrictRedis):
         else:
             for p in args:
                     pieces.append(str_path(p))
-        return self.execute_command('JSON.GET', *pieces)
+
+        # Handle case where key doesn't exist. The JSONDecoder would raise a
+        # TypeError exception since it can't decode None
+        try:
+            return self.execute_command('JSON.GET', *pieces)
+        except TypeError:
+            return None
 
     def jsonmget(self, path, *args):
         """

--- a/tests/test_rejson.py
+++ b/tests/test_rejson.py
@@ -21,6 +21,7 @@ class ReJSONTestCase(TestCase):
 
         self.assertTrue(rj.jsonset('foo', Path.rootPath(), 'bar'))
         self.assertEqual('bar', rj.jsonget('foo'))
+        self.assertEqual(None, rj.jsonget('baz'))
         self.assertEqual(1, rj.jsondel('foo'))
         self.assertFalse(rj.exists('foo'))
 


### PR DESCRIPTION
Add exception handler for .jsonget for non-existent keys (taken in PR#11, from @cjtapper) + added the test coverage necessary for the merge.

I just finished the work of @cjtapper, added the one line missing for the automatic merge.
It is to fix #9 

+ Added blank lines in the client.py file for PEP8 compliance. 

(It's my first pull request, so I'm sorry in advance if I don't follow the proper etiquette!)

